### PR TITLE
Create puppet master and 3 agent nodes

### DIFF
--- a/code/environments/production/environment.conf
+++ b/code/environments/production/environment.conf
@@ -1,0 +1,18 @@
+# Each environment can have an environment.conf file. Its settings will only
+# affect its own environment. See docs for more info:
+# https://docs.puppetlabs.com/puppet/latest/reference/config_file_environment.html
+
+# Any unspecified settings use default values; some of those defaults are based
+# on puppet.conf settings.
+
+# If these settings include relative file paths, they'll be resolved relative to
+# this environment's directory.
+
+# Allowed settings and default values:
+
+# modulepath = ./modules:$basemodulepath
+# manifest = (default_manifest from puppet.conf, which defaults to ./manifests)
+# config_version = (no script; Puppet will use the time the catalog was compiled)
+# environment_timeout = (environment_timeout from puppet.conf, which defaults to 0)
+    # Note: unless you have a specific reason, we recommend only setting
+    # environment_timeout in puppet.conf.

--- a/code/hiera.yaml
+++ b/code/hiera.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:hierarchy:
+  - "nodes/%{::trusted.certname}"
+  - common
+:yaml:
+  :datadir:

--- a/puppetserver/conf.d/auth.conf
+++ b/puppetserver/conf.d/auth.conf
@@ -1,0 +1,126 @@
+authorization: {
+    version: 1
+    rules: [
+        {
+            # Allow nodes to retrieve their own catalog
+            match-request: {
+                path: "^/puppet/v3/catalog/([^/]+)$"
+                type: regex
+                method: [get, post]
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs catalog"
+        },
+        {
+            # Allow nodes to retrieve the certificate they requested earlier
+            match-request: {
+                path: "/puppet-ca/v1/certificate/"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs certificate"
+        },
+        {
+            # Allow all nodes to access the certificate revocation list
+            match-request: {
+                path: "/puppet-ca/v1/certificate_revocation_list/ca"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs crl"
+        },
+        {
+            # Allow nodes to request a new certificate
+            match-request: {
+                path: "/puppet-ca/v1/certificate_request"
+                type: path
+                method: [get, put]
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs csr"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/environments"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs environments"
+        },
+        {
+            # Allow nodes to access all file services; this is necessary for
+            # pluginsync, file serving from modules, and file serving from
+            # custom mount points (see fileserver.conf). Note that the `/file`
+            # prefix matches requests to file_metadata, file_content, and
+            # file_bucket_file paths.
+            match-request: {
+                path: "/puppet/v3/file"
+                type: path
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file"
+        },
+        {
+            # Allow nodes to retrieve only their own node definition
+            match-request: {
+                path: "^/puppet/v3/node/([^/]+)$"
+                type: regex
+                method: get
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs node"
+        },
+        {
+            # Allow nodes to store only their own reports
+            match-request: {
+                path: "^/puppet/v3/report/([^/]+)$"
+                type: regex
+                method: put
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs report"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/status"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/static_file_content"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs static file content"
+        },
+        {
+          # Deny everything else. This ACL is not strictly
+          # necessary, but illustrates the default policy
+          match-request: {
+            path: "/"
+            type: path
+          }
+          deny: "*"
+          sort-order: 999
+          name: "puppetlabs deny all"
+        }
+    ]
+}

--- a/puppetserver/conf.d/global.conf
+++ b/puppetserver/conf.d/global.conf
@@ -1,0 +1,5 @@
+global: {
+    # Path to logback logging configuration file; for more
+    # info, see http://logback.qos.ch/manual/configuration.html
+    logging-config: /etc/puppetlabs/puppetserver/logback.xml
+}

--- a/puppetserver/conf.d/puppetserver.conf
+++ b/puppetserver/conf.d/puppetserver.conf
@@ -1,0 +1,68 @@
+# configuration for the JRuby interpreters
+jruby-puppet: {
+    # Where the puppet-agent dependency places puppet, facter, etc...
+    # Puppet server expects to load Puppet from this location
+    ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
+
+    # This setting determines where JRuby will look for gems.  It is also
+    # used by the `puppetserver gem` command line tool.
+    gem-home: /opt/puppetlabs/server/data/puppetserver/jruby-gems
+
+
+    # PLEASE NOTE: Use caution when modifying the below settings. Modifying
+    # these settings will change the value of the corresponding Puppet settings
+    # for Puppet Server, but not for the Puppet CLI tools. This likely will not
+    # be a problem with master-var-dir, master-run-dir, or master-log-dir unless
+    # some critical setting in puppet.conf is interpolating the value of one
+    # of the corresponding settings, but it is important that any changes made to
+    # master-conf-dir and master-code-dir are also made to the corresponding Puppet
+    # settings when running the Puppet CLI tools. See
+    # https://docs.puppetlabs.com/puppetserver/latest/puppet_conf_setting_diffs.html#overriding-puppet-settings-in-puppet-server
+    # for more information.
+
+    # (optional) path to puppet conf dir; if not specified, will use
+    # /etc/puppetlabs/puppet
+    master-conf-dir: /etc/puppetlabs/puppet
+
+    # (optional) path to puppet code dir; if not specified, will use
+    # /etc/puppetlabs/code
+    master-code-dir: /etc/puppetlabs/code
+
+    # (optional) path to puppet var dir; if not specified, will use
+    # /opt/puppetlabs/server/data/puppetserver
+    master-var-dir: /opt/puppetlabs/server/data/puppetserver
+
+    # (optional) path to puppet run dir; if not specified, will use
+    # /var/run/puppetlabs/puppetserver
+    master-run-dir: /var/run/puppetlabs/puppetserver
+
+    # (optional) path to puppet log dir; if not specified, will use
+    # /var/log/puppetlabs/puppetserver
+    master-log-dir: /var/log/puppetlabs/puppetserver
+
+    # (optional) maximum number of JRuby instances to allow
+    #max-active-instances: 1
+
+    # (optional) Authorize access to Puppet master endpoints via rules specified
+    # in the legacy Puppet auth.conf file (if true or not specified) or via rules
+    # specified in the Puppet Server HOCON-formatted auth.conf (if false).
+    #use-legacy-auth-conf: false
+}
+
+# settings related to HTTP client requests made by Puppet Server
+http-client: {
+    # A list of acceptable protocols for making HTTP requests
+    #ssl-protocols: [TLSv1, TLSv1.1, TLSv1.2]
+
+    # A list of acceptable cipher suites for making HTTP requests
+    #cipher-suites: [TLS_RSA_WITH_AES_256_CBC_SHA256,
+    #                TLS_RSA_WITH_AES_256_CBC_SHA,
+    #                TLS_RSA_WITH_AES_128_CBC_SHA256,
+    #                TLS_RSA_WITH_AES_128_CBC_SHA]
+}
+
+# settings related to profiling the puppet Ruby code
+profiler: {
+    # enable or disable profiling for the Ruby code; defaults to 'false'.
+    #enabled: true
+}

--- a/puppetserver/conf.d/web-routes.conf
+++ b/puppetserver/conf.d/web-routes.conf
@@ -1,0 +1,13 @@
+web-router-service: {
+    # These two should not be modified because the Puppet 4.x agent expects them to
+    # be mounted at these specific paths
+    "puppetlabs.services.ca.certificate-authority-service/certificate-authority-service": "/puppet-ca"
+    "puppetlabs.services.master.master-service/master-service": "/puppet"
+    "puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service": ""
+
+    # This controls the mount point for the puppet admin API.
+    "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"
+
+    # This controls the mount point for the status API
+    "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
+}

--- a/puppetserver/conf.d/webserver.conf
+++ b/puppetserver/conf.d/webserver.conf
@@ -1,0 +1,6 @@
+webserver: {
+    access-log-config: /etc/puppetlabs/puppetserver/request-logging.xml
+    client-auth: want
+    ssl-host: 0.0.0.0
+    ssl-port: 8140
+}

--- a/puppetserver/logback.xml
+++ b/puppetserver/logback.xml
@@ -1,0 +1,33 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%t] [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="F1" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- TODO: this path should not be hard-coded -->
+        <file>/var/log/puppetlabs/puppetserver/puppetserver.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- rollover daily -->
+            <fileNamePattern>/var/log/puppetlabs/puppetserver/puppetserver-%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d %-5p [%t] [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+
+    <root level="info">
+        <!--<appender-ref ref="STDOUT"/>-->
+        <!-- ${logappender} logs to console when running the foreground command -->
+        <appender-ref ref="${logappender}"/>
+        <appender-ref ref="F1"/>
+    </root>
+</configuration>

--- a/puppetserver/request-logging.xml
+++ b/puppetserver/request-logging.xml
@@ -1,0 +1,17 @@
+<configuration debug="false" scan="true">
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/var/log/puppetlabs/puppetserver/puppetserver-access.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy"><!-- rollover daily -->
+            <fileNamePattern>/var/log/puppetlabs/puppetserver/puppetserver-access-%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
+        </encoder>
+    </appender>
+    <appender-ref ref="FILE" />
+</configuration>

--- a/puppetserver/services.d/ca.cfg
+++ b/puppetserver/services.d/ca.cfg
@@ -1,0 +1,5 @@
+# To enable the CA service, leave the following line uncommented
+puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+# To disable the CA service, comment out the above line and uncomment the line below
+#puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,80 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+    # configure hostmanager
+    config.hostmanager.enabled = true
+    config.hostmanager.ignore_private_ip = false
+    config.hostmanager.include_offline = true
+
+    # puppetmaster on Centos 7
+    config.vm.define "puppet" do |puppet|
+        config.vm.provider "virtualbox" do |v|
+            v.memory = 2048
+        end
+
+        puppet.vm.box = "centos/7"
+        puppet.vm.hostname = "puppet.example.com"
+        puppet.vm.network :private_network, ip: "10.0.20.10"
+        puppet.hostmanager.aliases = %w(puppet)
+        puppet.vm.synced_folder ".", "/home/vagrant/sync"
+        puppet.vm.synced_folder "../code", "/puppet_code"
+        puppet.vm.synced_folder "../puppetserver", "/puppet_puppetserver"
+        puppet.vm.provision "shell", inline: <<-SHELL
+            sudo yum -y update
+            sudo yum -y install epel-release
+            sudo rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
+            sudo yum -y install puppetserver
+            sudo rm -rf /etc/puppetlabs/code
+            sudo ln -s /puppet_code /etc/puppetlabs/code
+            sudo rm -rf /etc/puppetlabs/puppetserver
+            sudo ln -s /puppet_puppetserver /etc/puppetlabs/puppetserver
+            sudo sed -i 's/2g/512m/g' /etc/sysconfig/puppetserver
+            echo "*.example.com" | sudo tee --append /etc/puppetlabs/puppet/autosign.conf > /dev/null
+            sudo systemctl start puppetserver
+        SHELL
+    end
+
+    # puppet agent1 on Centos 7
+    config.vm.define "agent1" do |agent1|
+        agent1.vm.box = "centos/7"
+        agent1.vm.hostname = "agent1.example.com"
+        agent1.vm.network :private_network, ip: "10.0.20.11"
+        agent1.hostmanager.aliases = %w(agent1)
+        agent1.vm.provision "shell", inline: <<-SHELL
+            sudo yum -y update
+            sudo yum -y install epel-release
+            sudo rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
+            sudo yum -y install puppet-agent
+            sudo systemctl start puppet
+        SHELL
+    end
+
+    # puppet agent2 on Debian Jessie
+    config.vm.define "agent2" do |agent2|
+        agent2.vm.box = "debian/jessie64"
+        agent2.vm.hostname = "agent2.example.com"
+        agent2.vm.network :private_network, ip: "10.0.20.12"
+        agent2.hostmanager.aliases = %w(agent2)
+        agent2.vm.provision "shell", inline: <<-SHELL
+            wget https://apt.puppetlabs.com/puppetlabs-release-pc1-jessie.deb
+            sudo dpkg -i puppetlabs-release-pc1-jessie.deb
+            sudo apt-get -y update
+            sudo apt-get -y install puppet-agent
+            sudo /opt/puppetlabs/bin/puppet agent --enable
+            sudo service puppet start
+        SHELL
+    end
+
+    # puppet agent2 on Windows2012 R2
+    config.vm.define "agent3" do |agent3|
+        agent3.vm.box = "devopsguys/Windows2012R2Eval"
+        agent3.vm.hostname = "agent3"
+        agent3.vm.network :private_network, ip: "10.0.20.13"
+        agent3.hostmanager.aliases = %w(agent3)
+        agent3.vm.provision "shell", :path => "windows.ps1"
+    end
+end

--- a/vagrant/windows.ps1
+++ b/vagrant/windows.ps1
@@ -1,0 +1,67 @@
+<#
+.SYNOPSIS
+    Installs Puppet on this machine.
+
+.DESCRIPTION
+    Downloads and installs the PuppetLabs Puppet MSI package.
+
+    This script requires administrative privileges.
+
+    You can run this script from an old-style cmd.exe prompt using the
+    following:
+
+      powershell.exe -ExecutionPolicy Unrestricted -NoLogo -NoProfile -Command "& '.\windows.ps1'"
+
+.PARAMETER MsiUrl
+    This is the URL to the Puppet MSI file you want to install. This defaults
+    to a version from PuppetLabs.
+
+.PARAMETER PuppetVersion
+    This is the version of Puppet that you want to install. If you pass this it will override the version in the MsiUrl.
+    This defaults to $null.
+#>
+param(
+   [string]$MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-3.3.2.msi"
+  ,[string]$PuppetVersion = $null
+)
+
+if ($PuppetVersion) {
+  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-$($PuppetVersion).msi"
+  Write-Host "Puppet version $PuppetVersion specified, updated MsiUrl to `"$MsiUrl`""
+}
+
+$PuppetInstalled = $false
+try {
+  $ErrorActionPreference = "Stop";
+  Get-Command puppet | Out-Null
+  $PuppetInstalled = $true
+  $PuppetVersion=&puppet "--version"
+  Write-Host "Puppet $PuppetVersion is installed. This process does not ensure the exact version or at least version specified, but only that puppet is installed. Exiting..."
+  Exit 0
+} catch {
+  Write-Host "Puppet is not installed, continuing..."
+}
+
+if (!($PuppetInstalled)) {
+  $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+  if (! ($currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))) {
+    Write-Host -ForegroundColor Red "You must run this script as an administrator."
+    Exit 1
+  }
+
+  # Install it - msiexec will download from the url
+  $install_args = @("/qn", "/norestart","/i", $MsiUrl)
+  Write-Host "Installing Puppet. Running msiexec.exe $install_args"
+  $process = Start-Process -FilePath msiexec.exe -ArgumentList $install_args -Wait -PassThru
+  if ($process.ExitCode -ne 0) {
+    Write-Host "Installer failed."
+    Exit 1
+  }
+
+  # Stop the service that it autostarts
+  Write-Host "Stopping Puppet service that is running by default..."
+  Start-Sleep -s 5
+  Stop-Service -Name puppet
+
+  Write-Host "Puppet successfully installed."
+}


### PR DESCRIPTION
Node details are
- puppet master is centos 7.
- puppet agent1 is centos 7.
- puppet agent2 is debian jessie.
- puppet agent3 is windows 2012 r2.

Vagrant plugin vagrant-vbguest needs to be installed on host
in order for shared folders to work with centos 7.

Bringing up windows agent machine fails so certain steps need
to be done manually
- vagrant up agent3 and let it fail
- start vm from virtualbox
- login to windows using vagrant/vagrant
- start service puppet agent
- add master node to hosts file manually
- run puppet agent -t so the agent requests certificate
- login to puppet master and issue the certificate
- run puppet agent -t to verify that certificate is issued and things
  working fine
